### PR TITLE
[BUGFIX] Fix printing of student payslips

### DIFF
--- a/school_fees/report/report_student_payslip.py
+++ b/school_fees/report/report_student_payslip.py
@@ -15,7 +15,7 @@ class ReportStudentPayslip(models.AbstractModel):
         return out_date
 
     @api.model
-    def get_report_values(self, docids, data=None):
+    def _get_report_values(self, docids, data=None):
         student_payslip = self.env['student.payslip'].search([('id', 'in',
                                                                docids)])
         payslip_model = self.env['ir.actions.report'].\


### PR DESCRIPTION
Student payslips could not be generated, because Odoo was not able to
find the method to get data for the report.

Fixed the typo of `get_report_values` to be `_get_report_values`.